### PR TITLE
ファイルを作成、wcコマンド模倣を記述

### DIFF
--- a/06.wc/wc_ruby.rb
+++ b/06.wc/wc_ruby.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'etc'
+
+def directory?(file)
+  File.directory?(file)
+end
+
+def output_dir(file)
+  puts "wc: #{file}: read: Is a directory"
+end
+
+def count_words(file)
+  line = file.count("\n")
+  word = file.split(/\s+/).size
+  byte = file.bytesize
+  [line, word, byte]
+end
+
+def output_count(files, option)
+  files.each do |file|
+    print file[0].to_s.rjust(8)
+    print file[1].to_s.rjust(8) unless option['l']
+    print file[2].to_s.rjust(8) unless option['l']
+    puts "\s#{file[3]}"
+  end
+end
+
+def output_total_count(total, option, std_flg)
+  print total[0].to_s.rjust(8)
+  print total[1].to_s.rjust(8) unless option['l']
+  print total[2].to_s.rjust(8) unless option['l']
+  puts std_flg ? "\n" : "\stotal"
+end
+
+def read_files(file)
+  File.read(file)
+end
+
+def culculate_arguments(files)
+  result = []
+  total = []
+  files.each do |file|
+    if directory?(file)
+      output_dir(file)
+    else
+      result << count_words(read_files(file))
+    end
+  end
+  result.transpose.each do |transposed_result|
+    total << transposed_result.sum
+  end
+  files.each do |file|
+    result = result.map { |array| array.push(file) }
+  end
+  { result: result, total: total }
+end
+
+def culculate_standard_input(files)
+  result = []
+  total = []
+  files.each do |file|
+    result << count_words(file)
+  end
+  result.transpose.each do |transposed_result|
+    total << transposed_result.sum
+  end
+  { result: result, total: total }
+end
+
+def main
+  option = ARGV.getopts('l')
+  std_in_flg = false
+
+  if ARGV.empty?
+    std_in_flg = true
+    count_std_words = culculate_standard_input(readlines)
+    output_total_count(count_std_words[:total], option, std_in_flg) if count_std_words[:result].size > 1
+  else
+    count_words = culculate_arguments(ARGV)
+    output_count(count_words[:result], option)
+    output_total_count(count_words[:total], option, std_in_flg) if count_words[:result].size > 1
+  end
+end
+
+main


### PR DESCRIPTION
wcコマンドを作成いたしました。
レビューお願いいたします。

・引数ファイル、標準入力を受け取ることができます。
・渡された入力物から計算して行数、単語数、バイト数、ファイル名を出力します。
・-l オプションが指定されている場合はバイト数とファイル名のみを出力します。
・ディレクトリが引数に指定された場合は、エラーを出力します。
・複数計算した場合は最終行に合計を出力します。
・引数ファイルと標準入力が同時に渡された場合、引数ファイルを計算して出力します。

ディレクトリの判断を行い、エラーを出す部分についてタイミングが上手く制御できず、
実際の引数の順番ではなく、固定で最初に出力されてしまう点がうまくできていないです。